### PR TITLE
Fixes UMD wrapper - Check for exports first

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// UMD HEADER START 
+// UMD HEADER START
 (function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define([], factory);
-    } else if (typeof exports === 'object') {
+    if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like enviroments that support module.exports,
         // like Node.
         module.exports = factory();
+    } else if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], factory);
     } else {
         // Browser globals (root is window)
         root.returnExports = factory();


### PR DESCRIPTION
We've run into situations where an AMD library is
being loaded a page that also includes a CommonJS
module runtime. Giving more precedence to exports
avoids problems.
